### PR TITLE
Make middleware actually enforce route protection

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -80,7 +80,18 @@ export default function LoginPage() {
             user.roles?.includes("superadmin") || user.isSuperadmin;
           const isAdmin = user.roles?.includes("admin");
 
-          if (isSuperAdmin) {
+          const redirectTo = new URLSearchParams(window.location.search).get(
+            "redirect",
+          );
+          const isSafeRedirect =
+            redirectTo &&
+            redirectTo.startsWith("/") &&
+            !redirectTo.startsWith("//") &&
+            redirectTo !== "/login";
+
+          if (isSafeRedirect) {
+            router.push(redirectTo);
+          } else if (isSuperAdmin) {
             router.push("/superadmin");
           } else if (isAdmin) {
             router.push("/admin");

--- a/src/components/UserContext.tsx
+++ b/src/components/UserContext.tsx
@@ -5,6 +5,7 @@ import { apiGet, apiPost } from "@/utils/api";
 import { login as authLogin, logout as authLogout } from "@/lib/auth-client";
 import { AppModuleKey, CrmEntitlements, normalizeCrmEntitlements, normalizeEnabledModules } from '@/utils/moduleAccess';
 import { getEffectiveTenantManifest } from '@/utils/manifest/manifestClient';
+import { setSessionMarker, clearSessionMarker } from '@/utils/authSession';
 
 export interface User {
   id: string;
@@ -333,6 +334,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children, skipUserFe
       setUser(normalizedUser);
       setLoading(false);
       setError(null);
+      setSessionMarker();
       // Keep initialized so we don't refetch on redirect (avoids 401/hang when cookies aren't sent cross-origin)
       initializedRef.current = true;
       await new Promise((r) => setTimeout(r, 100));
@@ -349,6 +351,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children, skipUserFe
       setEntitlementsSyncedAt(null);
       setError(err instanceof Error ? err.message : 'Login failed');
       if (typeof window !== 'undefined') localStorage.removeItem('token');
+      clearSessionMarker();
     } finally {
       setLoading(false);
     }
@@ -357,6 +360,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children, skipUserFe
   const logout = useCallback(async () => {
     await authLogout();
     if (typeof window !== 'undefined') localStorage.removeItem('token');
+    clearSessionMarker();
     clearUserCache();
     setUser(null);
     setEntitlementsSyncedAt(null);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,32 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-// No authentication middleware applied
-export function middleware() {
+/**
+ * The real session lives in an httpOnly cookie set by the backend, which in
+ * production is on a different origin (Vercel frontend + duckdns API) and
+ * never reaches this server. `has_session` is a same-origin marker cookie
+ * set client-side by UserContext right after a successful login (see
+ * src/utils/authSession.ts) purely so this middleware has something to check
+ * — it is not itself a credential. Actual authorization of every request
+ * still happens on the backend via the real JWT.
+ */
+export function middleware(request: NextRequest) {
+  const hasSession = request.cookies.has('has_session');
+  if (!hasSession) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('redirect', request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
   return NextResponse.next();
 }
 
+// Previously this only matched /dashboard and /profile, but almost none of the
+// app's protected pages (e.g. /accounting, /crm, /hr, /sales, /superadmin,
+// /(settings)/*) actually live under /dashboard, so they were unprotected
+// regardless of the check above. Gate everything except the known-public
+// auth pages, the shareable receipt view, Next.js API routes (which enforce
+// their own auth against the backend), and static assets.
 export const config = {
-  matcher: ['/dashboard/:path*', '/profile'],
+  matcher: [
+    '/((?!_next/static|_next/image|api|login|register|forgot-password|reset-password|receipt|favicon.ico|.*\\..*).*)',
+  ],
 };

--- a/src/utils/authSession.ts
+++ b/src/utils/authSession.ts
@@ -1,0 +1,20 @@
+/**
+ * The real auth token lives in an httpOnly cookie set by the backend, which is
+ * on a different origin in production (Vercel frontend + duckdns API) and so
+ * never reaches this app's own server-side code (middleware, RSCs). This
+ * same-origin, non-httpOnly marker cookie carries no secret — it only lets
+ * middleware.ts know a login has happened, so it can gate /dashboard and
+ * /profile at the edge instead of relying solely on a client-side redirect.
+ */
+const SESSION_MARKER_COOKIE = 'has_session';
+
+export function setSessionMarker(): void {
+  if (typeof document === 'undefined') return;
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${SESSION_MARKER_COOKIE}=1; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax${secure}`;
+}
+
+export function clearSessionMarker(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${SESSION_MARKER_COOKIE}=; path=/; max-age=0; SameSite=Lax`;
+}


### PR DESCRIPTION
## Summary
- `middleware.ts` was a literal no-op ("No authentication middleware applied") with a matcher covering only `/dashboard` and `/profile` — routes almost none of the app's real pages live under (e.g. `/`, `/accounting`, `/crm`, `/hr`, `/sales`, `/superadmin` were all unprotected). Protected pages rendered client-side before any redirect could fire.
- The real session cookie is httpOnly and, in production, lives on a different origin than the frontend (Vercel app + separate API domain), so middleware can never read it directly.
- Added a same-origin, non-httpOnly `has_session` marker cookie (`src/utils/authSession.ts`), set right after a successful login and cleared on logout. It carries no secret — it only tells middleware a login happened.
- `middleware.ts` now redirects to `/login?redirect=<path>` when that cookie is absent, and the matcher covers the whole app except known-public routes (login/register/password-reset/receipt), Next.js API routes, and static assets.
- Login page now honors the `redirect` query param so users land back where they intended after authenticating.

## Test plan
Verified against the running dev server (not just typecheck) — see verification notes below.

- [x] `tsc --noEmit`: zero errors on all touched files
- [x] `GET /` and `GET /accounting` with no session cookie → `307` to `/login?redirect=...` (previously unprotected)
- [x] Same routes with the `has_session` cookie set → `200`, passes through
- [x] `/login`, `/register` with no cookie → `200`, not redirected
- [x] `/manifest.json` (static asset) → `200`, not redirected
- [x] `/receipt/some-id` (public shareable receipt) → `200`, not redirected
- [x] `POST /api/ai/chat` with no cookie → `400` (its own validation error), not an HTML redirect — confirms API routes bypass the page-gating middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)