### PR TITLE
Re-enable 6 inventory/product reports now that their backend endpoint…

### DIFF
--- a/src/app/products/reports/inventory-aging/page.tsx
+++ b/src/app/products/reports/inventory-aging/page.tsx
@@ -46,6 +46,8 @@ type InventoryItem = {
   lastReceived: string | null;
   daysInStock: number;
   ageBucket: string;
+  unitCost: number;
+  stockValue: number;
 };
 
 export default function InventoryAgingReportPage() {
@@ -77,7 +79,7 @@ export default function InventoryAgingReportPage() {
     '90+': filteredItems.filter(item => item.ageBucket === '90+').length,
   };
 
-  const totalValue = filteredItems.reduce((sum, item) => sum + (item.stock * 100), 0); // Assuming average price of 100
+  const totalValue = filteredItems.reduce((sum, item) => sum + item.stockValue, 0);
   const slowMovingItems = filteredItems.filter(item => item.daysInStock > 90);
   const obsoleteItems = filteredItems.filter(item => item.daysInStock > 180);
 

--- a/src/app/products/reports/inventory-movement/page.tsx
+++ b/src/app/products/reports/inventory-movement/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-
+import { apiGet } from "@/utils/api";
 import { Line, Bar } from "react-chartjs-2";
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
@@ -56,22 +56,14 @@ export default function InventoryMovementReportPage() {
   const { data: tenantData } = useTenant();
   const [movements, setMovements] = useState<MovementData[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-
-    // Simulate movement data
-    const mockMovements: MovementData[] = [
-      { date: '2024-01-01', receipts: 150, issues: 120, adjustments: 5, netMovement: 35 },
-      { date: '2024-01-02', receipts: 200, issues: 180, adjustments: -3, netMovement: 17 },
-      { date: '2024-01-03', receipts: 180, issues: 160, adjustments: 2, netMovement: 22 },
-      { date: '2024-01-04', receipts: 220, issues: 200, adjustments: 1, netMovement: 21 },
-      { date: '2024-01-05', receipts: 190, issues: 170, adjustments: -2, netMovement: 18 },
-      { date: '2024-01-06', receipts: 210, issues: 190, adjustments: 3, netMovement: 23 },
-      { date: '2024-01-07', receipts: 170, issues: 150, adjustments: 0, netMovement: 20 },
-    ];
-    setMovements(mockMovements);
-    setLoading(false);
+    const headers = selectedBranchId ? { 'x-branch-id': selectedBranchId } : undefined;
+    apiGet("/analytics/inventory-movement", headers)
+      .then((data) => setMovements(data as MovementData[]))
+      .catch((err: unknown) => setError((err as Error).message || "An error occurred while fetching data."))
+      .finally(() => setLoading(false));
   }, [selectedBranchId]);
 
   const movementChartData = {

--- a/src/app/products/reports/inventory-turnover/page.tsx
+++ b/src/app/products/reports/inventory-turnover/page.tsx
@@ -43,6 +43,7 @@ ChartJS.register(
 );
 
 type TurnoverData = {
+  id: string;
   product: string;
   turnover: number;
   avgStock: number;
@@ -58,20 +59,10 @@ export default function InventoryTurnoverReportPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    
-    Promise.all([
-      apiGet(`/analytics/dashboard`)
-    ]).then(([analyticsData]) => {
-      // Type analyticsData as Record<string, unknown>
-      const topProducts = (analyticsData as { topProducts?: { name: string; unitsSold: number }[] }).topProducts || [];
-      const simulatedTurnover = topProducts.map((p) => ({
-        product: p.name,
-        turnover: Math.random() * 12 + 1, // Random turnover between 1-13
-        avgStock: Math.floor(Math.random() * 100) + 20,
-        sold: p.unitsSold
-      }));
-      setTurnoverData(simulatedTurnover);
-    }).catch((err: unknown) => setError((err as Error).message || "An error occurred while fetching data."))
+    const headers = selectedBranchId ? { 'x-branch-id': selectedBranchId } : undefined;
+    apiGet("/analytics/inventory-turnover", headers)
+      .then((data) => setTurnoverData(data as TurnoverData[]))
+      .catch((err: unknown) => setError((err as Error).message || "An error occurred while fetching data."))
       .finally(() => setLoading(false));
   }, [selectedBranchId]);
 
@@ -278,7 +269,7 @@ export default function InventoryTurnoverReportPage() {
                 </thead>
                 <tbody>
                   {turnoverData.map((data) => (
-                    <tr key={data.product} className="border-b">
+                    <tr key={data.id} className="border-b">
                       <td className="py-2 px-4">{data.product}</td>
                       <td className="py-2 px-4">{data.turnover.toFixed(2)}</td>
                       <td className="py-2 px-4">{data.avgStock}</td>

--- a/src/app/products/reports/page.tsx
+++ b/src/app/products/reports/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { FaExclamationTriangle, FaBox, FaShoppingCart, FaFilePdf, FaFileExcel, FaTh, FaList, FaFileAlt } from "react-icons/fa";
+import { FaExclamationTriangle, FaBox, FaShoppingCart, FaFilePdf, FaFileExcel, FaTh, FaList, FaFileAlt, FaSyncAlt, FaLayerGroup, FaExchangeAlt, FaClock, FaMoneyBillWave, FaBan } from "react-icons/fa";
 import { hasPermission } from "@/utils/permissions";
 import { useUser } from "@/components/UserContext";
 
@@ -45,51 +45,63 @@ const reports: Report[] = [
     icon: FaExclamationTriangle,
     category: 'inventory',
     requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'inventory-turnover',
+    title: 'Inventory Turnover',
+    description: 'How quickly each product sells relative to stock on hand, over the last 30 days.',
+    icon: FaSyncAlt,
+    category: 'inventory',
+    requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'inventory-movement',
+    title: 'Inventory Movement',
+    description: 'Daily receipts, issues, and adjustments recorded against your stock.',
+    icon: FaExchangeAlt,
+    category: 'inventory',
+    requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'inventory-aging',
+    title: 'Inventory Aging',
+    description: 'How long stock has been sitting since it was last received, by age bucket.',
+    icon: FaClock,
+    category: 'inventory',
+    requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'inventory-valuation',
+    title: 'Inventory Valuation',
+    description: 'Financial value of current stock, including cost, potential revenue, and margin.',
+    icon: FaMoneyBillWave,
+    category: 'inventory',
+    requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'stockout-lost-sales',
+    title: 'Stockout & Lost Sales',
+    description: 'Products currently out of stock and the estimated sales lost while unavailable.',
+    icon: FaBan,
+    category: 'inventory',
+    requiredPermission: 'view_inventory'
+  },
+  {
+    id: 'product-category-analysis',
+    title: 'Product Category Analysis',
+    description: 'Revenue, units sold, and margin performance broken down by product category.',
+    icon: FaLayerGroup,
+    category: 'products',
+    requiredPermission: 'view_sales'
   }
 ];
 
 const hiddenReports: HiddenReportStatus[] = [
   {
-    id: 'inventory-turnover',
-    title: 'Inventory Turnover',
-    reason: 'Uses simulated/random values in frontend.',
-    endpoint: 'GET /analytics/inventory-turnover',
-  },
-  {
     id: 'supplier-performance',
     title: 'Supplier Performance',
-    reason: 'Uses hardcoded mock supplier records.',
+    reason: 'No purchase-order or delivery-tracking data exists in the schema to compute this from — would require a new data model, not just a new endpoint.',
     endpoint: 'GET /analytics/supplier-performance',
-  },
-  {
-    id: 'product-category-analysis',
-    title: 'Product Category Analysis',
-    reason: 'No valid report page is currently implemented.',
-    endpoint: 'GET /analytics/product-category-analysis',
-  },
-  {
-    id: 'inventory-movement',
-    title: 'Inventory Movement',
-    reason: 'Uses static fake movement data.',
-    endpoint: 'GET /analytics/inventory-movement',
-  },
-  {
-    id: 'inventory-aging',
-    title: 'Inventory Aging',
-    reason: 'Backend endpoint missing and value assumptions in frontend.',
-    endpoint: 'GET /analytics/inventory-aging',
-  },
-  {
-    id: 'stockout-lost-sales',
-    title: 'Stockout & Lost Sales',
-    reason: 'Frontend expects endpoint that is not implemented.',
-    endpoint: 'GET /analytics/stockout-lost-sales',
-  },
-  {
-    id: 'inventory-valuation',
-    title: 'Inventory Valuation',
-    reason: 'Frontend expects endpoint that is not implemented.',
-    endpoint: 'GET /analytics/inventory-valuation',
   },
 ];
 

--- a/src/app/products/reports/product-category-analysis/page.tsx
+++ b/src/app/products/reports/product-category-analysis/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+import { useEffect, useState } from "react";
+import { apiGet } from "@/utils/api";
+import { Bar } from "react-chartjs-2";
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import * as XLSX from 'xlsx';
+import { useTenant } from '@/hooks/useTenant';
+import {
+  getPdfDocOptions,
+  getPdfMargin,
+  getPdfFontSize,
+  applyPdfBusinessHeader,
+  applyPdfFooterAndPageNumbers,
+  getPdfTableColors,
+  getPdfCurrency,
+  type PdfTemplate,
+  preparePdfWatermark,
+} from '@/utils/pdfTemplate';
+import { getFullAssetUrl } from '@/utils/logoUrl';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { FaFilePdf, FaFileExcel } from "react-icons/fa";
+import { useBranch } from "@/contexts/BranchContext";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+type CategoryItem = {
+  categoryId: string;
+  categoryName: string;
+  revenue: number;
+  unitsSold: number;
+  marginPct: number;
+  stockValue: number;
+};
+
+export default function ProductCategoryAnalysisReportPage() {
+  const branchContext = useBranch();
+  const selectedBranchId = branchContext?.selectedBranchId;
+  const { data: tenantData } = useTenant();
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const headers = selectedBranchId ? { 'x-branch-id': selectedBranchId } : undefined;
+    apiGet("/analytics/product-category-analysis", headers)
+      .then((data) => setCategories(data as CategoryItem[]))
+      .catch((err: unknown) => setError((err as Error).message || "An error occurred while fetching data."))
+      .finally(() => setLoading(false));
+  }, [selectedBranchId]);
+
+  const totalRevenue = categories.reduce((sum, c) => sum + c.revenue, 0);
+  const totalUnitsSold = categories.reduce((sum, c) => sum + c.unitsSold, 0);
+  const totalStockValue = categories.reduce((sum, c) => sum + c.stockValue, 0);
+  const averageMargin = categories.length > 0
+    ? categories.reduce((sum, c) => sum + c.marginPct, 0) / categories.length
+    : 0;
+
+  const revenueChartData = {
+    labels: categories.slice(0, 10).map(c => c.categoryName.length > 15 ? c.categoryName.substring(0, 15) + '...' : c.categoryName),
+    datasets: [{
+      label: 'Revenue (Ksh)',
+      data: categories.slice(0, 10).map(c => c.revenue),
+      backgroundColor: '#3b82f6',
+      borderRadius: 4,
+    }],
+  };
+
+  const exportToPDF = async () => {
+    const pdfTemplate = (tenantData?.pdfTemplate || {}) as PdfTemplate;
+    const currency = getPdfCurrency(tenantData, pdfTemplate);
+    const margin = getPdfMargin(pdfTemplate);
+    const fontSize = getPdfFontSize(pdfTemplate);
+    const { primaryRgb, secondaryRgb } = getPdfTableColors(pdfTemplate);
+
+    const doc = new jsPDF(getPdfDocOptions(pdfTemplate));
+    await preparePdfWatermark(doc, getFullAssetUrl(tenantData?.watermark as string | null | undefined));
+    let yPosition = applyPdfBusinessHeader(doc, tenantData, pdfTemplate, margin);
+
+    doc.setFontSize(fontSize + 4);
+    doc.setTextColor((pdfTemplate.primaryColor || '#000000').replace('#', '') || '000000');
+    doc.text('Product Category Analysis Report', margin, yPosition + 8);
+    yPosition += 18;
+
+    doc.setFontSize(fontSize - 2);
+    doc.setTextColor('666666');
+    doc.text(`Generated: ${new Date().toLocaleString()}`, margin, yPosition);
+    yPosition += 6;
+    doc.text(`Total Categories: ${categories.length}`, margin, yPosition);
+    yPosition += 6;
+    doc.text(`Total Revenue: ${currency} ${totalRevenue.toLocaleString()}`, margin, yPosition);
+    yPosition += 6;
+    doc.text(`Average Margin: ${averageMargin.toFixed(1)}%`, margin, yPosition);
+    yPosition += 14;
+
+    doc.setFontSize(fontSize);
+    doc.setTextColor((pdfTemplate.primaryColor || '#000000').replace('#', '') || '000000');
+    doc.text('Category Details', margin, yPosition);
+    yPosition += 10;
+
+    const rows = categories.map((c, i) => [
+      i + 1,
+      c.categoryName,
+      c.unitsSold,
+      `${currency} ${c.revenue.toLocaleString()}`,
+      `${c.marginPct.toFixed(1)}%`,
+    ]);
+    if (rows.length) {
+      autoTable(doc, {
+        head: [['#', 'Category', 'Units Sold', `Revenue (${currency})`, 'Margin %']],
+        body: rows,
+        startY: yPosition,
+        styles: { fontSize: fontSize - 2, cellPadding: 3 },
+        headStyles: { fillColor: primaryRgb, textColor: [255, 255, 255], fontStyle: 'bold' },
+        alternateRowStyles: { fillColor: secondaryRgb },
+        margin: { left: margin, right: margin },
+      });
+    }
+
+    applyPdfFooterAndPageNumbers(doc, pdfTemplate, 'SaaS POS • Product Category Analysis');
+    const pdfBlob = doc.output('blob');
+    const url = URL.createObjectURL(pdfBlob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'product_category_analysis_report.pdf';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const exportToExcel = () => {
+    const workbook = XLSX.utils.book_new();
+
+    const excelData = [
+      ['Product Category Analysis Report'],
+      [],
+      ['Total Categories', categories.length],
+      ['Total Revenue', totalRevenue],
+      ['Total Units Sold', totalUnitsSold],
+      ['Total Stock Value', totalStockValue],
+      ['Average Margin', averageMargin.toFixed(1) + '%'],
+      [],
+      ['Category', 'Units Sold', 'Revenue', 'Margin %', 'Stock Value'],
+      ...categories.map(c => [
+        c.categoryName,
+        c.unitsSold,
+        c.revenue,
+        c.marginPct.toFixed(1) + '%',
+        c.stockValue,
+      ]),
+    ];
+
+    const worksheet = XLSX.utils.aoa_to_sheet(excelData);
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Category Analysis');
+
+    XLSX.writeFile(workbook, 'product_category_analysis_report.xlsx');
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[300px]">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center h-screen bg-gray-50">
+        <div className="bg-red-100 border border-red-400 text-red-700 px-6 py-4 rounded-lg shadow-md" role="alert">
+          <strong className="font-bold">Failed to load data:</strong>
+          <span className="block sm:inline ml-2">{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 sm:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <header className="mb-10">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight">Product Category Analysis</h1>
+              <p className="mt-2 text-lg text-gray-500">Revenue, units sold, and margin performance broken down by product category.</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={exportToPDF}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors flex items-center gap-2"
+              >
+                <FaFilePdf />
+                Export PDF
+              </button>
+              <button
+                onClick={exportToExcel}
+                className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors flex items-center gap-2"
+              >
+                <FaFileExcel />
+                Export Excel
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">Key Metrics</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-xl shadow p-6 flex flex-col items-center border border-blue-200">
+              <span className="text-blue-600 text-sm mb-1 font-medium">Categories</span>
+              <span className="text-3xl font-bold text-blue-700">{categories.length}</span>
+            </div>
+            <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-xl shadow p-6 flex flex-col items-center border border-green-200">
+              <span className="text-green-600 text-sm mb-1 font-medium">Total Revenue</span>
+              <span className="text-3xl font-bold text-green-700">Ksh {totalRevenue.toLocaleString()}</span>
+            </div>
+            <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-xl shadow p-6 flex flex-col items-center border border-purple-200">
+              <span className="text-purple-600 text-sm mb-1 font-medium">Units Sold</span>
+              <span className="text-3xl font-bold text-purple-700">{totalUnitsSold.toLocaleString()}</span>
+            </div>
+            <div className="bg-gradient-to-br from-orange-50 to-orange-100 rounded-xl shadow p-6 flex flex-col items-center border border-orange-200">
+              <span className="text-orange-600 text-sm mb-1 font-medium">Avg Margin</span>
+              <span className="text-3xl font-bold text-orange-700">{averageMargin.toFixed(1)}%</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-bold text-gray-800 mb-6">Revenue by Category (Top 10)</h2>
+          <div className="bg-white rounded-xl shadow p-6">
+            <div className="h-64">
+              <Bar
+                data={revenueChartData}
+                options={{
+                  responsive: true,
+                  maintainAspectRatio: false,
+                  plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                      callbacks: {
+                        label: function(context) {
+                          return `Revenue: Ksh ${Number(context.parsed.y ?? 0).toLocaleString()}`;
+                        }
+                      }
+                    }
+                  },
+                  scales: {
+                    y: {
+                      beginAtZero: true,
+                      grid: { color: 'rgba(0, 0, 0, 0.1)' },
+                      ticks: {
+                        callback: function(value) {
+                          return 'Ksh ' + value.toLocaleString();
+                        }
+                      }
+                    },
+                    x: {
+                      grid: { color: 'rgba(0, 0, 0, 0.1)' }
+                    }
+                  }
+                }}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">Category Details ({categories.length})</h2>
+          <div className="bg-white rounded-xl shadow p-6">
+            <div className="overflow-x-auto">
+              <table className="min-w-full">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="py-2 px-4 text-left font-semibold text-gray-600">Category</th>
+                    <th className="py-2 px-4 text-left font-semibold text-gray-600">Units Sold</th>
+                    <th className="py-2 px-4 text-left font-semibold text-gray-600">Revenue</th>
+                    <th className="py-2 px-4 text-left font-semibold text-gray-600">Margin</th>
+                    <th className="py-2 px-4 text-left font-semibold text-gray-600">Stock Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {categories.map((c) => (
+                    <tr key={c.categoryId} className="border-b">
+                      <td className="py-2 px-4">{c.categoryName}</td>
+                      <td className="py-2 px-4">{c.unitsSold}</td>
+                      <td className="py-2 px-4">Ksh {c.revenue.toLocaleString()}</td>
+                      <td className={`py-2 px-4 font-medium ${
+                        c.marginPct < 20 ? 'text-red-600' :
+                        c.marginPct > 50 ? 'text-green-600' : 'text-yellow-600'
+                      }`}>
+                        {c.marginPct.toFixed(1)}%
+                      </td>
+                      <td className="py-2 px-4">Ksh {c.stockValue.toLocaleString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…s exist

products/reports/page.tsx was hiding these behind an admin-only "awaiting backend" table. Now that backend endpoints exist and are verified working:

- inventory-turnover, inventory-movement: previously used Math.random() simulation / hardcoded mock arrays despite calling (or being able to call) a real backend. Rewired to call the real endpoint.
- inventory-aging, inventory-valuation, stockout-lost-sales: already called the right endpoint but were still hidden.
- product-category-analysis: had no page at all; added one following the existing report-page structure (key metrics, chart, PDF/Excel export, detail table).

Also fixed inventory-aging's "Assuming average price of 100" placeholder now that the backend provides real per-item stockValue, and a React duplicate-key warning in inventory-turnover surfaced by real data having multiple products with the same name (was using product name as the table key instead of product id).

Supplier Performance stays hidden — no purchase-order/delivery-tracking data exists in the schema to compute it from honestly.